### PR TITLE
cert-manager-basic: use cert-manager namespace for leaderelection

### DIFF
--- a/cert-manager-basic/cainjector/deployment-cert-manager-cainjector.yaml
+++ b/cert-manager-basic/cainjector/deployment-cert-manager-cainjector.yaml
@@ -35,7 +35,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
-          - --leader-election-namespace=kube-system
+          - --leader-election-namespace=$(POD_NAMESPACE)
           env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/cert-manager-basic/cainjector/role-cert-manager-cainjector:leaderelection.yaml
+++ b/cert-manager-basic/cainjector/role-cert-manager-cainjector:leaderelection.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cert-manager-cainjector:leaderelection
-  namespace: kube-system
+  namespace: cert-manager
   labels:
     app: cainjector
     app.kubernetes.io/name: cainjector

--- a/cert-manager-basic/cainjector/rolebinding-cert-manager-cainjector:leaderelection.yaml
+++ b/cert-manager-basic/cainjector/rolebinding-cert-manager-cainjector:leaderelection.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cert-manager-cainjector:leaderelection
-  namespace: kube-system
+  namespace: cert-manager
   labels:
     app: cainjector
     app.kubernetes.io/name: cainjector

--- a/cert-manager-basic/cert-manager/deployment-cert-manager.yaml
+++ b/cert-manager-basic/cert-manager/deployment-cert-manager.yaml
@@ -41,7 +41,7 @@ spec:
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
-          - --leader-election-namespace=kube-system
+          - --leader-election-namespace=$(POD_NAMESPACE)
           ports:
           - containerPort: 9402
             name: http-metrics

--- a/cert-manager-basic/cert-manager/role-cert-manager:leaderelection.yaml
+++ b/cert-manager-basic/cert-manager/role-cert-manager:leaderelection.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cert-manager:leaderelection
-  namespace: kube-system
+  namespace: cert-manager
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager

--- a/cert-manager-basic/cert-manager/rolebinding-cert-manager:leaderelection.yaml
+++ b/cert-manager-basic/cert-manager/rolebinding-cert-manager:leaderelection.yaml
@@ -5,7 +5,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cert-manager:leaderelection
-  namespace: kube-system
+  namespace: cert-manager
   labels:
     app: cert-manager
     app.kubernetes.io/name: cert-manager


### PR DESCRIPTION
In some environments such as GKE autopilot, extensions such as cert-manager will not have access to system namespaces such as `kube-system`.

I am not sure why `kube-system` was being used in the first place, but anyways, this PR instructs all components to use the `cert-manager` namespace.