### PR TITLE
A simple POC to change non KRM files to a structured k8s resource

### DIFF
--- a/ghost/configmap-formatter/Dockerfile
+++ b/ghost/configmap-formatter/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:20.04
+
+RUN apt-get update -y
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
+   python3 \
+   python3-pip \
+   python3-virtualenv \
+   && update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+
+WORKDIR /app
+
+RUN mkdir -p /src/code
+RUN mkdir -p /app
+
+COPY env-to-ini.py /src/code
+
+CMD [ "python3", "/src/code/env-to-ini.py"]

--- a/ghost/configmap-formatter/env-to-ini.py
+++ b/ghost/configmap-formatter/env-to-ini.py
@@ -1,0 +1,39 @@
+import os
+import collections
+import configparser 
+from os.path import exists
+
+CM_PREFIX = "cm." 
+DELIMITER = "."
+INI_FILE_NAME_ENV = "CM_INI_FILE_NAME"
+DEFAULT_INI_FILE = "my.cnf"
+
+def iniFileNameFromEnv():
+    iniFromEnv = os.environ[INI_FILE_NAME_ENV]
+    return iniFromEnv if iniFromEnv else DEFAULT_INI_FILE
+
+def run():
+    config = configparser.ConfigParser()
+
+    iniContent = readFromEnv()
+    config.read_dict(iniContent)
+
+    with open(iniFileNameFromEnv(), 'w') as iniFile:
+        config.write(iniFile)
+
+
+def readFromEnv():
+    iniContent = collections.defaultdict(dict)
+    for envKey, value in os.environ.items():
+        if envKey.startswith(CM_PREFIX):
+            _, section, key = envKey.split(DELIMITER)
+            iniContent[section][key] = value
+    return iniContent
+
+
+if __name__ == "__main__":
+    run()
+    iniFile = os.path.abspath(iniFileNameFromEnv())
+    if not exists(iniFile):
+        os.exit(1)
+    print(f"Successfully write to {iniFile}.")

--- a/ghost/mariadb/configmap-mariadb.yaml
+++ b/ghost/mariadb/configmap-mariadb.yaml
@@ -7,32 +7,26 @@ metadata:
   labels:
     app.kubernetes.io/name: mariadb
 data:
-  my.ini: |-
-    [mysqld]
-    skip-name-resolve
-    explicit_defaults_for_timestamp
-    basedir=/opt/bitnami/mariadb
-    plugin_dir=/opt/bitnami/mariadb/plugin
-    port=3306
-    socket=/opt/bitnami/mariadb/tmp/mysql.sock
-    tmpdir=/opt/bitnami/mariadb/tmp
-    max_allowed_packet=16M
-    bind-address=*
-    pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
-    log-error=/opt/bitnami/mariadb/logs/mysqld.log
-    character-set-server=UTF8
-    collation-server=utf8_general_ci
-    slow_query_log=0
-    slow_query_log_file=/opt/bitnami/mariadb/logs/mysqld.log
-    long_query_time=10.0
-
-    [client]
-    port=3306
-    socket=/opt/bitnami/mariadb/tmp/mysql.sock
-    default-character-set=UTF8
-    plugin_dir=/opt/bitnami/mariadb/plugin
-
-    [manager]
-    port=3306
-    socket=/opt/bitnami/mariadb/tmp/mysql.sock
-    pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
+  cm.mysqld.skip-name-resolve: "false"
+  cm.mysqld.explicit_defaults_for_timestamp: "ON"
+  cm.mysqld.basedir: /opt/bitnami/mariadb
+  cm.mysqld.plugin_dir: /opt/bitnami/mariadb/plugin
+  cm.mysqld.port: "3308"
+  cm.mysqld.socket: /opt/bitnami/mariadb/tmp/mysql.sock
+  cm.mysqld.tmpdir: /opt/bitnami/mariadb/tmp
+  cm.mysqld.max_allowed_packet: 16M
+  cm.mysqld.bind-address: '*'
+  cm.mysqld.pid-file: /opt/bitnami/mariadb/tmp/mysqld.pid
+  cm.mysqld.log-error: /opt/bitnami/mariadb/logs/mysqld.log
+  cm.mysqld.character-set-server: UTF8
+  cm.mysqld.collation-server: utf8_general_ci
+  cm.mysqld.slow_query_log: "0"
+  cm.mysqld.slow_query_log_file: /opt/bitnami/mariadb/logs/mysqld.log
+  cm.mysqld.long_query_time: "10.0"
+  cm.client.port: "3308"
+  cm.client.socket: /opt/bitnami/mariadb/tmp/mysql.sock
+  cm.client.default-character-set: UTF8
+  cm.client.plugin_dir: /opt/bitnami/mariadb/plugin
+  cm.manager.port: "3308"
+  cm.manager.socket: /opt/bitnami/mariadb/tmp/mysql.sock
+  cm.manager.pid-file: /opt/bitnami/mariadb/tmp/mysqld.pid

--- a/ghost/mariadb/statefulset-mariadb.yaml
+++ b/ghost/mariadb/statefulset-mariadb.yaml
@@ -16,6 +16,28 @@ spec:
     spec:
       securityContext:
         fsGroup: 1001
+      initContainers:
+      - name: configmap-map-to-file
+        image: gcr.io/kpt-fn-demo/yuwenma-cm-env-to-ini:v0.12
+        env:
+        - name: CM_INI_FILE_NAME
+          value: my.cnf
+        envFrom:
+        - configMapRef:
+            name: mariadb
+        volumeMounts:
+        - name: ini-config
+          # the env-to-ini.py cannot be placed in the same mount dir.
+          # Because it will be overridden.
+          mountPath: /app
+      - name: verify
+        image: ubuntu
+        command: ["/bin/sh","-c"]
+        args: ["ls /tmp; cat /tmp/my.cnf"]
+        volumeMounts:
+          - name: ini-config
+            mountPath: /tmp/my.cnf
+            subPath: my.cnf
       containers:
         - name: mariadb
           image: docker.io/bitnami/mariadb:10.6.7-debian-10-r62
@@ -24,44 +46,43 @@ spec:
             runAsNonRoot: true
             runAsUser: 1001
           env:
-            - name: BITNAMI_DEBUG
-              value: "true"
-            - name: MARIADB_USER
-              value: bn_ghost
-            - name: MARIADB_DATABASE
-              value: bitnami_ghost
-            - name: ALLOW_EMPTY_PASSWORD
-              value: "true"
+          - name: BITNAMI_DEBUG
+            value: "true"
+          - name: MARIADB_USER
+            value: bn_ghost
+          - name: MARIADB_DATABASE
+            value: bitnami_ghost
+          - name: ALLOW_EMPTY_PASSWORD
+            value: "true"
           ports:
-            - name: mysql
-              containerPort: 3306
+          - name: mysql
+            containerPort: 3307
           resources:
             limits: {}
             requests: {}
           volumeMounts:
-            - name: data
-              mountPath: /bitnami/mariadb
-            - name: config
-              mountPath: /opt/bitnami/mariadb/conf/my.ini
-              subPath: my.ini
+          - name: data
+            mountPath: /bitnami/mariadb
+          - name: ini-config
+            mountPath: /opt/bitnami/mariadb/conf/my.cnf
+            subPath: my.cnf
       volumes:
-        - name: config
-          configMap:
-            name: mariadb
+      - name: ini-config
+        emptyDir: {}
     metadata:
       labels:
         app.kubernetes.io/name: mariadb
   volumeClaimTemplates:
-    - metadata:
-        name: data
-        labels:
-          app.kubernetes.io/name: mariadb
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 8Gi
+  - metadata:
+      name: data
+      labels:
+        app.kubernetes.io/name: mariadb
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 8Gi
   selector:
     matchLabels:
       app.kubernetes.io/name: mariadb


### PR DESCRIPTION
Related to [Sane merge behavior for non-KRM files](https://github.com/GoogleContainerTools/kpt/issues/3418)

This PR structures a INI file in the form of `ConfigMap` key-value pairs in the client side, so that kpt can do granular merging during update, and re-generate the actual INI by defining a custom initContainer (env-to-ini) on the cluster side.

