### PR TITLE
Bank of anthos: monolith pkg

### DIFF
--- a/bank-of-anthos/Kptfile
+++ b/bank-of-anthos/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: bank-of-anthos
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: sample description

--- a/bank-of-anthos/Kptfile
+++ b/bank-of-anthos/Kptfile
@@ -6,3 +6,7 @@ metadata:
     config.kubernetes.io/local-config: "true"
 info:
   description: sample description
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.4.1
+      configPath: package-context.yaml

--- a/bank-of-anthos/README.md
+++ b/bank-of-anthos/README.md
@@ -1,0 +1,21 @@
+# anthos-app
+
+## Description
+sample description
+
+## Usage
+
+### Fetch the package
+`kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] anthos-app`
+Details: https://kpt.dev/reference/cli/pkg/get/
+
+### View package content
+`kpt pkg tree anthos-app`
+Details: https://kpt.dev/reference/cli/pkg/tree/
+
+### Apply the package
+```
+kpt live init anthos-app
+kpt live apply anthos-app --reconcile-timeout=2m --output=table
+```
+Details: https://kpt.dev/reference/cli/live/

--- a/bank-of-anthos/accounts-db.yaml
+++ b/bank-of-anthos/accounts-db.yaml
@@ -1,0 +1,97 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_boa_kubernetes_manifests_accounts_db_statefulset_accounts_db]
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: accounts-db
+  labels:
+    app: accounts-db
+    tier: db
+spec:
+  serviceName: "accounts-db"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: accounts-db
+      tier: db
+  template:
+    metadata:
+      labels:
+        app: accounts-db
+        tier: db
+    spec:
+      serviceAccountName: default
+      containers:
+      - name: accounts-db
+        image: gcr.io/bank-of-anthos-ci/accounts-db:v0.5.6
+        envFrom:
+          - configMapRef:
+              name: environment-config
+          - configMapRef:
+              name: accounts-db-config
+          - configMapRef:
+              name: demo-data-config
+        ports:
+          - containerPort: 5432
+            name: postgredb
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 250m
+            memory: 512Mi
+        volumeMounts:
+        - name: postgresdb
+          mountPath: /var/lib/postgresql/data
+          subPath: postgres
+      volumes:
+      - name: postgresdb
+        emptyDir: {}
+# [END gke_boa_kubernetes_manifests_accounts_db_statefulset_accounts_db]
+---
+# [START gke_boa_kubernetes_manifests_accounts_db_service_accounts_db]
+apiVersion: v1
+kind: Service
+metadata:
+  name: accounts-db
+  labels:
+    app: accounts-db
+    tier: db
+spec:
+  ports:
+    - port: 5432
+      name: tcp
+      targetPort: 5432
+      protocol: TCP
+  selector:
+    app: accounts-db
+    tier: db
+# [END gke_boa_kubernetes_manifests_accounts_db_service_accounts_db]
+---
+# [START gke_boa_kubernetes_manifests_accounts_db_configmap_accounts_db_config]
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: accounts-db-config
+  labels:
+    app: accounts-db
+data:
+  POSTGRES_DB: accounts-db
+  POSTGRES_USER: accounts-admin
+  POSTGRES_PASSWORD: accounts-pwd
+  ACCOUNTS_DB_URI: postgresql://accounts-admin:accounts-pwd@accounts-db:5432/accounts-db
+# [END gke_boa_kubernetes_manifests_accounts_db_configmap_accounts_db_config]

--- a/bank-of-anthos/accounts-db.yaml
+++ b/bank-of-anthos/accounts-db.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # [START gke_boa_kubernetes_manifests_accounts_db_statefulset_accounts_db]
 kind: StatefulSet
 apiVersion: apps/v1
@@ -20,6 +19,7 @@ metadata:
   labels:
     app: accounts-db
     tier: db
+  namespace: example
 spec:
   serviceName: "accounts-db"
   replicas: 1
@@ -38,15 +38,15 @@ spec:
       - name: accounts-db
         image: gcr.io/bank-of-anthos-ci/accounts-db:v0.5.6
         envFrom:
-          - configMapRef:
-              name: environment-config
-          - configMapRef:
-              name: accounts-db-config
-          - configMapRef:
-              name: demo-data-config
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: accounts-db-config
+        - configMapRef:
+            name: demo-data-config
         ports:
-          - containerPort: 5432
-            name: postgredb
+        - containerPort: 5432
+          name: postgredb
         resources:
           requests:
             cpu: 100m
@@ -61,6 +61,7 @@ spec:
       volumes:
       - name: postgresdb
         emptyDir: {}
+        # [END gke_boa_kubernetes_manifests_accounts_db_statefulset_accounts_db]
 # [END gke_boa_kubernetes_manifests_accounts_db_statefulset_accounts_db]
 ---
 # [START gke_boa_kubernetes_manifests_accounts_db_service_accounts_db]
@@ -71,6 +72,7 @@ metadata:
   labels:
     app: accounts-db
     tier: db
+  namespace: example
 spec:
   ports:
     - port: 5432
@@ -80,6 +82,7 @@ spec:
   selector:
     app: accounts-db
     tier: db
+    # [END gke_boa_kubernetes_manifests_accounts_db_service_accounts_db]
 # [END gke_boa_kubernetes_manifests_accounts_db_service_accounts_db]
 ---
 # [START gke_boa_kubernetes_manifests_accounts_db_configmap_accounts_db_config]
@@ -89,9 +92,10 @@ metadata:
   name: accounts-db-config
   labels:
     app: accounts-db
+  namespace: example
 data:
   POSTGRES_DB: accounts-db
   POSTGRES_USER: accounts-admin
   POSTGRES_PASSWORD: accounts-pwd
   ACCOUNTS_DB_URI: postgresql://accounts-admin:accounts-pwd@accounts-db:5432/accounts-db
-# [END gke_boa_kubernetes_manifests_accounts_db_configmap_accounts_db_config]
+  # [END gke_boa_kubernetes_manifests_accounts_db_configmap_accounts_db_config]

--- a/bank-of-anthos/balance-reader.yaml
+++ b/bank-of-anthos/balance-reader.yaml
@@ -1,0 +1,134 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_boa_kubernetes_manifests_balance_reader_deployment_balancereader]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: balancereader
+spec:
+  selector:
+    matchLabels:
+      app: balancereader
+  template:
+    metadata:
+      labels:
+        app: balancereader
+    spec:
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+      - name: balancereader
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - all
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: gcr.io/bank-of-anthos-ci/balancereader:v0.5.6
+        volumeMounts:
+        - name: publickey
+          mountPath: "/tmp/.ssh"
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp
+        env:
+        - name: VERSION
+          value: "v0.5.6"
+        - name: PORT
+          value: "8080"
+        # toggle Cloud Trace export
+        - name: ENABLE_TRACING
+          value: "true"
+        - name: ENABLE_METRICS
+          value: "true"
+        - name: POLL_MS
+          value: "100"
+        - name: CACHE_SIZE
+          value: "1000000"
+        # tell Java to obey container memory limits
+        - name: JVM_OPTS
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xms256m -Xmx512m"
+        # Valid levels are debug, info, warn, error, fatal.
+        # If no valid level is set, will default to info.
+        - name: LOG_LEVEL
+          value: "info"
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        # add ledger-db credentials from ConfigMap
+        - configMapRef:
+            name: ledger-db-config
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 5
+          timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthy
+            port: 8080
+          initialDelaySeconds: 120
+          periodSeconds: 5
+          timeoutSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /healthy
+            port: 8080
+          failureThreshold: 30
+          periodSeconds: 10
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+      - emptyDir: {}
+        name: tmp
+# [END gke_boa_kubernetes_manifests_balance_reader_deployment_balancereader]
+---
+# [START gke_boa_kubernetes_manifests_balance_reader_service_balancereader]
+apiVersion: v1
+kind: Service
+metadata:
+  name: balancereader
+spec:
+  type: ClusterIP
+  selector:
+    app: balancereader
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+# [END gke_boa_kubernetes_manifests_balance_reader_service_balancereader]

--- a/bank-of-anthos/balance-reader.yaml
+++ b/bank-of-anthos/balance-reader.yaml
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # [START gke_boa_kubernetes_manifests_balance_reader_deployment_balancereader]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: balancereader
+  namespace: example
 spec:
   selector:
     matchLabels:
@@ -39,7 +39,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - all
+            - all
           privileged: false
           readOnlyRootFilesystem: true
         image: gcr.io/bank-of-anthos-ci/balancereader:v0.5.6
@@ -116,6 +116,7 @@ spec:
             path: publickey
       - emptyDir: {}
         name: tmp
+        # [END gke_boa_kubernetes_manifests_balance_reader_deployment_balancereader]
 # [END gke_boa_kubernetes_manifests_balance_reader_deployment_balancereader]
 ---
 # [START gke_boa_kubernetes_manifests_balance_reader_service_balancereader]
@@ -123,6 +124,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: balancereader
+  namespace: example
 spec:
   type: ClusterIP
   selector:
@@ -131,4 +133,4 @@ spec:
   - name: http
     port: 8080
     targetPort: 8080
-# [END gke_boa_kubernetes_manifests_balance_reader_service_balancereader]
+    # [END gke_boa_kubernetes_manifests_balance_reader_service_balancereader]

--- a/bank-of-anthos/config.yaml
+++ b/bank-of-anthos/config.yaml
@@ -1,0 +1,48 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_boa_kubernetes_manifests_config_configmap_environment_config]
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: environment-config
+data:
+  LOCAL_ROUTING_NUM: "883745000"
+  PUB_KEY_PATH: "/tmp/.ssh/publickey"
+# [END gke_boa_kubernetes_manifests_config_configmap_environment_config]
+---
+# [START gke_boa_kubernetes_manifests_config_configmap_service_api_config]
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: service-api-config
+data:
+  TRANSACTIONS_API_ADDR: "ledgerwriter:8080"
+  BALANCES_API_ADDR: "balancereader:8080"
+  HISTORY_API_ADDR: "transactionhistory:8080"
+  CONTACTS_API_ADDR: "contacts:8080"
+  USERSERVICE_API_ADDR: "userservice:8080"
+# [END gke_boa_kubernetes_manifests_config_configmap_service_api_config]
+---
+# [START gke_boa_kubernetes_manifests_config_configmap_demo_data_config]
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo-data-config
+data:
+  USE_DEMO_DATA: "True"
+  DEMO_LOGIN_USERNAME: "testuser"
+  # All demo user accounts are hardcoded to use the login password 'bankofanthos'
+  DEMO_LOGIN_PASSWORD: "bankofanthos"
+# [END gke_boa_kubernetes_manifests_config_configmap_demo_data_config]

--- a/bank-of-anthos/config.yaml
+++ b/bank-of-anthos/config.yaml
@@ -11,15 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # [START gke_boa_kubernetes_manifests_config_configmap_environment_config]
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: environment-config
+  namespace: example
 data:
   LOCAL_ROUTING_NUM: "883745000"
   PUB_KEY_PATH: "/tmp/.ssh/publickey"
+  # [END gke_boa_kubernetes_manifests_config_configmap_environment_config]
 # [END gke_boa_kubernetes_manifests_config_configmap_environment_config]
 ---
 # [START gke_boa_kubernetes_manifests_config_configmap_service_api_config]
@@ -27,12 +28,14 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: service-api-config
+  namespace: example
 data:
   TRANSACTIONS_API_ADDR: "ledgerwriter:8080"
   BALANCES_API_ADDR: "balancereader:8080"
   HISTORY_API_ADDR: "transactionhistory:8080"
   CONTACTS_API_ADDR: "contacts:8080"
   USERSERVICE_API_ADDR: "userservice:8080"
+  # [END gke_boa_kubernetes_manifests_config_configmap_service_api_config]
 # [END gke_boa_kubernetes_manifests_config_configmap_service_api_config]
 ---
 # [START gke_boa_kubernetes_manifests_config_configmap_demo_data_config]
@@ -40,9 +43,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: demo-data-config
+  namespace: example
 data:
   USE_DEMO_DATA: "True"
   DEMO_LOGIN_USERNAME: "testuser"
   # All demo user accounts are hardcoded to use the login password 'bankofanthos'
   DEMO_LOGIN_PASSWORD: "bankofanthos"
-# [END gke_boa_kubernetes_manifests_config_configmap_demo_data_config]
+  # [END gke_boa_kubernetes_manifests_config_configmap_demo_data_config]

--- a/bank-of-anthos/contacts.yaml
+++ b/bank-of-anthos/contacts.yaml
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # [START gke_boa_kubernetes_manifests_contacts_deployment_contacts]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: contacts
+  namespace: example
 spec:
   selector:
     matchLabels:
@@ -39,7 +39,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - all
+            - all
           privileged: false
           readOnlyRootFilesystem: true
         image: gcr.io/bank-of-anthos-ci/contacts:v0.5.6
@@ -88,6 +88,7 @@ spec:
             path: publickey
       - emptyDir: {}
         name: tmp
+        # [END gke_boa_kubernetes_manifests_contacts_deployment_contacts]
 # [END gke_boa_kubernetes_manifests_contacts_deployment_contacts]
 ---
 # [START gke_boa_kubernetes_manifests_contacts_service_contacts]
@@ -95,6 +96,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: contacts
+  namespace: example
 spec:
   type: ClusterIP
   selector:
@@ -103,4 +105,4 @@ spec:
   - name: http
     port: 8080
     targetPort: 8080
-# [END gke_boa_kubernetes_manifests_contacts_service_contacts]
+    # [END gke_boa_kubernetes_manifests_contacts_service_contacts]

--- a/bank-of-anthos/contacts.yaml
+++ b/bank-of-anthos/contacts.yaml
@@ -1,0 +1,106 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_boa_kubernetes_manifests_contacts_deployment_contacts]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: contacts
+spec:
+  selector:
+    matchLabels:
+      app: contacts
+  template:
+    metadata:
+      labels:
+        app: contacts
+    spec:
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+      - name: contacts
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - all
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: gcr.io/bank-of-anthos-ci/contacts:v0.5.6
+        volumeMounts:
+        - name: publickey
+          mountPath: "/tmp/.ssh"
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp
+        env:
+        - name: VERSION
+          value: "v0.5.6"
+        - name: PORT
+          value: "8080"
+        - name: ENABLE_TRACING
+          value: "true"
+        # Valid levels are debug, info, warning, error, critical.
+        # If no valid level is set, will default to info.
+        - name: LOG_LEVEL
+          value: "info"
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: accounts-db-config
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 250m
+            memory: 128Mi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 10
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+      - emptyDir: {}
+        name: tmp
+# [END gke_boa_kubernetes_manifests_contacts_deployment_contacts]
+---
+# [START gke_boa_kubernetes_manifests_contacts_service_contacts]
+apiVersion: v1
+kind: Service
+metadata:
+  name: contacts
+spec:
+  type: ClusterIP
+  selector:
+    app: contacts
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+# [END gke_boa_kubernetes_manifests_contacts_service_contacts]

--- a/bank-of-anthos/frontend.yaml
+++ b/bank-of-anthos/frontend.yaml
@@ -1,0 +1,151 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_boa_kubernetes_manifests_frontend_deployment_frontend]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+      - name: front
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - all
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: gcr.io/bank-of-anthos-ci/frontend:v0.5.6
+        volumeMounts:
+        - name: publickey
+          mountPath: "/tmp/.ssh"
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp
+        env:
+        - name: VERSION
+          value: "v0.5.6"
+        - name: PORT
+          value: "8080"
+        - name: ENABLE_TRACING
+          value: "true"
+        - name: SCHEME
+          value: "http"
+         # Valid levels are debug, info, warning, error, critical. If no valid level is set, gunicorn will default to info.
+        - name: LOG_LEVEL
+          value: "info"
+        # Set to "true" to enable the CymbalBank logo + title
+        # - name: CYMBAL_LOGO
+        #   value: "false"
+        # Customize the bank name used in the header. Defaults to 'Bank of Anthos' - when CYMBAL_LOGO is true, uses 'CymbalBank'
+        # - name: BANK_NAME
+        #   value: ""
+        # Customize the cluster name if it cannot be retrieved from the metadata server
+        #- name: CLUSTER_NAME
+        #  value: "my-cluster"
+        - name: DEFAULT_USERNAME
+          valueFrom:
+            configMapKeyRef:
+              name: demo-data-config
+              key: DEMO_LOGIN_USERNAME
+        - name: DEFAULT_PASSWORD
+          valueFrom:
+            configMapKeyRef:
+              name: demo-data-config
+              key: DEMO_LOGIN_PASSWORD
+        - name: REGISTERED_OAUTH_CLIENT_ID
+          valueFrom:
+            configMapKeyRef:
+              name: oauth-config
+              key: DEMO_OAUTH_CLIENT_ID
+              optional: true
+        - name: ALLOWED_OAUTH_REDIRECT_URI
+          valueFrom:
+            configMapKeyRef:
+              name: oauth-config
+              key: DEMO_OAUTH_REDIRECT_URI
+              optional: true
+        # Customize the metadata server hostname to query for metadata
+        #- name: METADATA_SERVER
+        #  value: "my-metadata-server"
+        # Customize the pod zone if it cannot be retrieved from the metadata server
+        #- name: POD_ZONE
+        #  value: "my-zone"
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: service-api-config
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 15
+          timeoutSeconds: 30
+        resources:
+          requests:
+            cpu: 100m
+            memory: 64Mi
+          limits:
+            cpu: 250m
+            memory: 128Mi
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+      - emptyDir: {}
+        name: tmp
+# [END gke_boa_kubernetes_manifests_frontend_deployment_frontend]
+---
+# [START gke_boa_kubernetes_manifests_frontend_service_frontend]
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+spec:
+  type: LoadBalancer
+  selector:
+    app: frontend
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080
+# [END gke_boa_kubernetes_manifests_frontend_service_frontend]

--- a/bank-of-anthos/frontend.yaml
+++ b/bank-of-anthos/frontend.yaml
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # [START gke_boa_kubernetes_manifests_frontend_deployment_frontend]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
+  namespace: example
 spec:
   selector:
     matchLabels:
@@ -39,7 +39,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - all
+            - all
           privileged: false
           readOnlyRootFilesystem: true
         image: gcr.io/bank-of-anthos-ci/frontend:v0.5.6
@@ -58,7 +58,7 @@ spec:
           value: "true"
         - name: SCHEME
           value: "http"
-         # Valid levels are debug, info, warning, error, critical. If no valid level is set, gunicorn will default to info.
+          # Valid levels are debug, info, warning, error, critical. If no valid level is set, gunicorn will default to info.
         - name: LOG_LEVEL
           value: "info"
         # Set to "true" to enable the CymbalBank logo + title
@@ -133,6 +133,7 @@ spec:
             path: publickey
       - emptyDir: {}
         name: tmp
+        # [END gke_boa_kubernetes_manifests_frontend_deployment_frontend]
 # [END gke_boa_kubernetes_manifests_frontend_deployment_frontend]
 ---
 # [START gke_boa_kubernetes_manifests_frontend_service_frontend]
@@ -140,6 +141,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: frontend
+  namespace: example
 spec:
   type: LoadBalancer
   selector:
@@ -148,4 +150,5 @@ spec:
   - name: http
     port: 80
     targetPort: 8080
+    # [END gke_boa_kubernetes_manifests_frontend_service_frontend]
 # [END gke_boa_kubernetes_manifests_frontend_service_frontend]

--- a/bank-of-anthos/ledger-db.yaml
+++ b/bank-of-anthos/ledger-db.yaml
@@ -1,0 +1,89 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_boa_kubernetes_manifests_ledger_db_statefulset_ledger_db]
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: ledger-db
+spec:
+  serviceName: "ledger-db"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ledger-db
+  template:
+    metadata:
+      labels:
+        app: ledger-db
+    spec:
+      serviceAccountName: default
+      containers:
+        - name: postgres
+          image: gcr.io/bank-of-anthos-ci/ledger-db:v0.5.6
+          ports:
+            - containerPort: 5432
+          envFrom:
+            - configMapRef:
+                name: environment-config
+            - configMapRef:
+                name: ledger-db-config
+            - configMapRef:
+                name: demo-data-config
+          resources:
+            requests:
+              cpu: 100m
+              memory: 512Mi
+            limits:
+              cpu: 250m
+              memory: 1Gi
+          volumeMounts:
+            - name: postgresdb
+              mountPath: /var/lib/postgresql/data
+              subPath: postgres
+      volumes:
+        - name: postgresdb
+          emptyDir: {}
+# [END gke_boa_kubernetes_manifests_ledger_db_statefulset_ledger_db]
+---
+# [START gke_boa_kubernetes_manifests_ledger_db_configmap_ledger_db_config]
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ledger-db-config
+  labels:
+    app: postgres
+data:
+  POSTGRES_DB: postgresdb
+  POSTGRES_USER: admin
+  POSTGRES_PASSWORD: password
+  SPRING_DATASOURCE_URL: jdbc:postgresql://ledger-db:5432/postgresdb
+  SPRING_DATASOURCE_USERNAME: admin # should match POSTGRES_USER
+  SPRING_DATASOURCE_PASSWORD: password # should match POSTGRES_PASSWORD
+# [END gke_boa_kubernetes_manifests_ledger_db_configmap_ledger_db_config]
+---
+# [START gke_boa_kubernetes_manifests_ledger_db_service_ledger_db]
+apiVersion: v1
+kind: Service
+metadata:
+  name: ledger-db
+spec:
+  type: ClusterIP
+  selector:
+    app: ledger-db
+  ports:
+  - name: tcp
+    port: 5432
+    targetPort: 5432
+# [END gke_boa_kubernetes_manifests_ledger_db_service_ledger_db]

--- a/bank-of-anthos/ledger-db.yaml
+++ b/bank-of-anthos/ledger-db.yaml
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # [START gke_boa_kubernetes_manifests_ledger_db_statefulset_ledger_db]
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
   name: ledger-db
+  namespace: example
 spec:
   serviceName: "ledger-db"
   replicas: 1
@@ -55,6 +55,7 @@ spec:
       volumes:
         - name: postgresdb
           emptyDir: {}
+          # [END gke_boa_kubernetes_manifests_ledger_db_statefulset_ledger_db]
 # [END gke_boa_kubernetes_manifests_ledger_db_statefulset_ledger_db]
 ---
 # [START gke_boa_kubernetes_manifests_ledger_db_configmap_ledger_db_config]
@@ -64,6 +65,7 @@ metadata:
   name: ledger-db-config
   labels:
     app: postgres
+  namespace: example
 data:
   POSTGRES_DB: postgresdb
   POSTGRES_USER: admin
@@ -71,6 +73,7 @@ data:
   SPRING_DATASOURCE_URL: jdbc:postgresql://ledger-db:5432/postgresdb
   SPRING_DATASOURCE_USERNAME: admin # should match POSTGRES_USER
   SPRING_DATASOURCE_PASSWORD: password # should match POSTGRES_PASSWORD
+  # [END gke_boa_kubernetes_manifests_ledger_db_configmap_ledger_db_config]
 # [END gke_boa_kubernetes_manifests_ledger_db_configmap_ledger_db_config]
 ---
 # [START gke_boa_kubernetes_manifests_ledger_db_service_ledger_db]
@@ -78,6 +81,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ledger-db
+  namespace: example
 spec:
   type: ClusterIP
   selector:
@@ -86,4 +90,4 @@ spec:
   - name: tcp
     port: 5432
     targetPort: 5432
-# [END gke_boa_kubernetes_manifests_ledger_db_service_ledger_db]
+    # [END gke_boa_kubernetes_manifests_ledger_db_service_ledger_db]

--- a/bank-of-anthos/ledger-writer.yaml
+++ b/bank-of-anthos/ledger-writer.yaml
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # [START gke_boa_kubernetes_manifests_ledger_writer_deployment_ledgerwriter]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ledgerwriter
+  namespace: example
 spec:
   selector:
     matchLabels:
@@ -39,7 +39,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - all
+            - all
           privileged: false
           readOnlyRootFilesystem: true
         image: gcr.io/bank-of-anthos-ci/ledgerwriter:v0.5.6
@@ -58,7 +58,7 @@ spec:
           value: "true"
         - name: ENABLE_METRICS
           value: "true"
-         # tell Java to obey container memory limits
+          # tell Java to obey container memory limits
         - name: JVM_OPTS
           value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xms256m -Xmx512m"
         # service level override of log level
@@ -105,6 +105,7 @@ spec:
             path: publickey
       - emptyDir: {}
         name: tmp
+        # [END gke_boa_kubernetes_manifests_ledger_writer_deployment_ledgerwriter]
 # [END gke_boa_kubernetes_manifests_ledger_writer_deployment_ledgerwriter]
 ---
 # [START gke_boa_kubernetes_manifests_ledger_writer_service_ledgerwriter]
@@ -112,6 +113,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ledgerwriter
+  namespace: example
 spec:
   type: ClusterIP
   selector:
@@ -120,4 +122,4 @@ spec:
   - name: http
     port: 8080
     targetPort: 8080
-# [END gke_boa_kubernetes_manifests_ledger_writer_service_ledgerwriter]
+    # [END gke_boa_kubernetes_manifests_ledger_writer_service_ledgerwriter]

--- a/bank-of-anthos/ledger-writer.yaml
+++ b/bank-of-anthos/ledger-writer.yaml
@@ -1,0 +1,123 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_boa_kubernetes_manifests_ledger_writer_deployment_ledgerwriter]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ledgerwriter
+spec:
+  selector:
+    matchLabels:
+      app: ledgerwriter
+  template:
+    metadata:
+      labels:
+        app: ledgerwriter
+    spec:
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+      - name: ledgerwriter
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - all
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: gcr.io/bank-of-anthos-ci/ledgerwriter:v0.5.6
+        volumeMounts:
+        - name: publickey
+          mountPath: "/tmp/.ssh"
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp
+        env:
+        - name: VERSION
+          value: "v0.5.6"
+        - name: PORT
+          value: "8080"
+        - name: ENABLE_TRACING
+          value: "true"
+        - name: ENABLE_METRICS
+          value: "true"
+         # tell Java to obey container memory limits
+        - name: JVM_OPTS
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xms256m -Xmx512m"
+        # service level override of log level
+        - name: LOG_LEVEL
+          value: "info"
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: service-api-config
+        # add ledger-db credentials from ConfigMap
+        - configMapRef:
+            name: ledger-db-config
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 5
+          timeoutSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          failureThreshold: 30
+          periodSeconds: 10
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+      - emptyDir: {}
+        name: tmp
+# [END gke_boa_kubernetes_manifests_ledger_writer_deployment_ledgerwriter]
+---
+# [START gke_boa_kubernetes_manifests_ledger_writer_service_ledgerwriter]
+apiVersion: v1
+kind: Service
+metadata:
+  name: ledgerwriter
+spec:
+  type: ClusterIP
+  selector:
+    app: ledgerwriter
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+# [END gke_boa_kubernetes_manifests_ledger_writer_service_ledgerwriter]

--- a/bank-of-anthos/loadgenerator.yaml
+++ b/bank-of-anthos/loadgenerator.yaml
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # [START gke_boa_kubernetes_manifests_loadgenerator_deployment_loadgenerator]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: loadgenerator
+  namespace: example
 spec:
   selector:
     matchLabels:
@@ -43,7 +43,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - all
+            - all
           privileged: false
           readOnlyRootFilesystem: true
         image: gcr.io/bank-of-anthos-ci/loadgenerator:v0.5.6
@@ -61,4 +61,4 @@ spec:
           limits:
             cpu: 250m
             memory: 1Gi
-# [END gke_boa_kubernetes_manifests_loadgenerator_deployment_loadgenerator]
+            # [END gke_boa_kubernetes_manifests_loadgenerator_deployment_loadgenerator]

--- a/bank-of-anthos/loadgenerator.yaml
+++ b/bank-of-anthos/loadgenerator.yaml
@@ -1,0 +1,64 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_boa_kubernetes_manifests_loadgenerator_deployment_loadgenerator]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loadgenerator
+spec:
+  selector:
+    matchLabels:
+      app: loadgenerator
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: loadgenerator
+      annotations:
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+    spec:
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 5
+      restartPolicy: Always
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+      - name: loadgenerator
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - all
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: gcr.io/bank-of-anthos-ci/loadgenerator:v0.5.6
+        env:
+        - name: FRONTEND_ADDR
+          value: "frontend:80"
+        - name: USERS
+          value: "5"
+        - name: LOG_LEVEL
+          value: "error"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 512Mi
+          limits:
+            cpu: 250m
+            memory: 1Gi
+# [END gke_boa_kubernetes_manifests_loadgenerator_deployment_loadgenerator]

--- a/bank-of-anthos/package-context.yaml
+++ b/bank-of-anthos/package-context.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  name: example

--- a/bank-of-anthos/transaction-history.yaml
+++ b/bank-of-anthos/transaction-history.yaml
@@ -1,0 +1,139 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_boa_kubernetes_manifests_transaction_history_deployment_transactionhistory]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: transactionhistory
+spec:
+  selector:
+    matchLabels:
+      app: transactionhistory
+  template:
+    metadata:
+      labels:
+        app: transactionhistory
+    spec:
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+      - name: transactionhistory
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - all
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: gcr.io/bank-of-anthos-ci/transactionhistory:v0.5.6
+        volumeMounts:
+        - name: publickey
+          mountPath: "/tmp/.ssh"
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp
+        env:
+        - name: VERSION
+          value: "v0.5.6"
+        - name: PORT
+          value: "8080"
+        - name: ENABLE_TRACING
+          value: "true"
+        - name: ENABLE_METRICS
+          value: "true"
+        - name: POLL_MS
+          value: "100"
+        - name: CACHE_SIZE
+          value: "1000"
+        - name: CACHE_MINUTES
+          value: "60"
+        - name: HISTORY_LIMIT
+          value: "100"
+          # tell Java to obey container memory limits
+        - name: JVM_OPTS
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Xms256m -Xmx512m"
+        #- name: EXTRA_LATENCY_MILLIS
+        #  value: "5000"
+        # Valid levels are debug, info, warn, error, fatal.
+        # If no valid level is set, will default to info.
+        - name: LOG_LEVEL
+          value: "info"
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        # add ledger-db credentials from ConfigMap
+        - configMapRef:
+            name: ledger-db-config
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 60
+          periodSeconds: 5
+          timeoutSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthy
+            port: 8080
+          initialDelaySeconds: 120
+          periodSeconds: 5
+          timeoutSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /healthy
+            port: 8080
+          failureThreshold: 30
+          periodSeconds: 10
+      volumes:
+      - name: publickey
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key.pub
+            path: publickey
+      - emptyDir: {}
+        name: tmp
+# [END gke_boa_kubernetes_manifests_transaction_history_deployment_transactionhistory]
+---
+# [START gke_boa_kubernetes_manifests_transaction_history_service_transactionhistory]
+apiVersion: v1
+kind: Service
+metadata:
+  name: transactionhistory
+spec:
+  type: ClusterIP
+  selector:
+    app: transactionhistory
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+# [END gke_boa_kubernetes_manifests_transaction_history_service_transactionhistory]

--- a/bank-of-anthos/transaction-history.yaml
+++ b/bank-of-anthos/transaction-history.yaml
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # [START gke_boa_kubernetes_manifests_transaction_history_deployment_transactionhistory]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: transactionhistory
+  namespace: example
 spec:
   selector:
     matchLabels:
@@ -39,7 +39,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - all
+            - all
           privileged: false
           readOnlyRootFilesystem: true
         image: gcr.io/bank-of-anthos-ci/transactionhistory:v0.5.6
@@ -121,6 +121,7 @@ spec:
             path: publickey
       - emptyDir: {}
         name: tmp
+        # [END gke_boa_kubernetes_manifests_transaction_history_deployment_transactionhistory]
 # [END gke_boa_kubernetes_manifests_transaction_history_deployment_transactionhistory]
 ---
 # [START gke_boa_kubernetes_manifests_transaction_history_service_transactionhistory]
@@ -128,6 +129,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: transactionhistory
+  namespace: example
 spec:
   type: ClusterIP
   selector:
@@ -136,4 +138,4 @@ spec:
   - name: http
     port: 8080
     targetPort: 8080
-# [END gke_boa_kubernetes_manifests_transaction_history_service_transactionhistory]
+    # [END gke_boa_kubernetes_manifests_transaction_history_service_transactionhistory]

--- a/bank-of-anthos/userservice.yaml
+++ b/bank-of-anthos/userservice.yaml
@@ -1,0 +1,114 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_boa_kubernetes_manifests_userservice_deployment_userservice]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: userservice
+spec:
+  selector:
+    matchLabels:
+      app: userservice
+  template:
+    metadata:
+      labels:
+        app: userservice
+    spec:
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 5
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+      - name: userservice
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - all
+          privileged: false
+          readOnlyRootFilesystem: true
+        image: gcr.io/bank-of-anthos-ci/userservice:v0.5.6
+        volumeMounts:
+        - name: keys
+          mountPath: "/tmp/.ssh"
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp
+        ports:
+        - name: http-server
+          containerPort: 8080
+        env:
+        - name: VERSION
+          value: "v0.5.6"
+        - name: PORT
+          value: "8080"
+        - name: ENABLE_TRACING
+          value: "true"
+        - name: TOKEN_EXPIRY_SECONDS
+          value: "3600"
+        - name: PRIV_KEY_PATH
+          value: "/tmp/.ssh/privatekey"
+        # Valid levels are debug, info, warning, error, critical. If no valid level is set, gunicorn will default to info.
+        - name: LOG_LEVEL
+          value: "info"
+        envFrom:
+        - configMapRef:
+            name: environment-config
+        - configMapRef:
+            name: accounts-db-config
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 10
+        resources:
+          requests:
+            cpu: 200m
+            memory: 64Mi
+          limits:
+            cpu: 500m
+            memory: 256Mi
+      volumes:
+      - name: keys
+        secret:
+          secretName: jwt-key
+          items:
+          - key: jwtRS256.key
+            path: privatekey
+          - key: jwtRS256.key.pub
+            path: publickey
+      - emptyDir: {}
+        name: tmp
+# [END gke_boa_kubernetes_manifests_userservice_deployment_userservice]
+---
+# [START gke_boa_kubernetes_manifests_userservice_service_userservice]
+apiVersion: v1
+kind: Service
+metadata:
+  name: userservice
+spec:
+  type: ClusterIP
+  selector:
+    app: userservice
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+# [END gke_boa_kubernetes_manifests_userservice_service_userservice]

--- a/bank-of-anthos/userservice.yaml
+++ b/bank-of-anthos/userservice.yaml
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 # [START gke_boa_kubernetes_manifests_userservice_deployment_userservice]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: userservice
+  namespace: example
 spec:
   selector:
     matchLabels:
@@ -39,7 +39,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - all
+            - all
           privileged: false
           readOnlyRootFilesystem: true
         image: gcr.io/bank-of-anthos-ci/userservice:v0.5.6
@@ -96,6 +96,7 @@ spec:
             path: publickey
       - emptyDir: {}
         name: tmp
+        # [END gke_boa_kubernetes_manifests_userservice_deployment_userservice]
 # [END gke_boa_kubernetes_manifests_userservice_deployment_userservice]
 ---
 # [START gke_boa_kubernetes_manifests_userservice_service_userservice]
@@ -103,6 +104,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: userservice
+  namespace: example
 spec:
   type: ClusterIP
   selector:
@@ -111,4 +113,4 @@ spec:
   - name: http
     port: 8080
     targetPort: 8080
-# [END gke_boa_kubernetes_manifests_userservice_service_userservice]
+    # [END gke_boa_kubernetes_manifests_userservice_service_userservice]


### PR DESCRIPTION
This is a monolith package for `bank of anthos`. It uses `set-namespace` function to update the namespace of the resources.

I had to manually provision the `jwt` secret in the same namespace manually.

The intention of preparing this package is to have a baseline package that I can always refer incase things break when I work on the micro-service based model.