### PR TITLE
Headlamp demo script

### DIFF
--- a/headlamp-demo.sh
+++ b/headlamp-demo.sh
@@ -117,7 +117,7 @@ pause
 banner "Step 5: Deploy to cluster, expose port, and create service account token"
 
 run kpt live init
-run kpt live apply --reconcile-timeout=5m
+run kpt live apply --output=table --reconcile-timeout=5m
 
 echo ""
 echo -e "${GREEN}> kubectl port-forward -n kube-system service/headlamp 8080:80 &${RESET}"

--- a/headlamp-demo.sh
+++ b/headlamp-demo.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -e
+
+# Colors
+BOLD='\033[1m'
+CYAN='\033[0;36m'
+GREEN='\033[0;32m'
+RESET='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HEADLAMP_DIR="${SCRIPT_DIR}/headlamp"
+PORT_FORWARD_PID=""
+
+cleanup() {
+    local exit_code=$?
+    if [[ $exit_code -ne 0 ]]; then
+        echo ""
+        echo -e "\033[0;31m${BOLD}An error occurred. Running cleanup...${RESET}"
+    fi
+    if [[ -n "${PORT_FORWARD_PID}" ]]; then
+        kill "${PORT_FORWARD_PID}" 2>/dev/null || true
+    fi
+    kind delete cluster --name kpt-demo 2>/dev/null || true
+    rm -rf "${HEADLAMP_DIR}"
+}
+trap cleanup EXIT
+
+banner() {
+    echo ""
+    echo -e "${CYAN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+    echo -e "${CYAN}${BOLD}  $1${RESET}"
+    echo -e "${CYAN}${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+    echo ""
+}
+
+run() {
+    echo -e "${GREEN}> $*${RESET}"
+    "$@"
+}
+
+pause() {
+    echo ""
+    read -rp "Press Enter to continue to the next step..."
+    echo ""
+}
+
+# ─── Step 1 ───────────────────────────────────────────────────────────────────
+banner "Step 1: Create kind cluster 'kpt-demo'"
+
+run kind create cluster --name kpt-demo
+
+pause
+
+# ─── Step 2 ───────────────────────────────────────────────────────────────────
+banner "Step 2: Download headlamp KRM file and initialize kpt package"
+
+run mkdir -p "${HEADLAMP_DIR}"
+cd "${HEADLAMP_DIR}"
+
+run curl -sLO https://raw.githubusercontent.com/kubernetes-sigs/headlamp/main/kubernetes-headlamp.yaml
+
+echo -e "${BOLD}# Generating security configuration${RESET}"
+echo -e "${GREEN}> Generating headlamp-admin-sa.yaml${RESET}"
+cat > headlamp-admin-sa.yaml <<'EOF'
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: headlamp-admin
+  namespace: kube-system
+EOF
+
+echo -e "${GREEN}> Generating headlamp-admin-crb.yaml${RESET}"
+cat > headlamp-admin-crb.yaml <<'EOF'
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: headlamp-admin
+    namespace: kube-system
+EOF
+
+run kpt pkg init
+
+pause
+
+# ─── Step 3 ───────────────────────────────────────────────────────────────────
+banner "Step 3: Add set-label mutator pipeline to Kptfile"
+
+echo -e "${GREEN}> Appending pipeline block to Kptfile${RESET}"
+cat >> Kptfile <<'EOF'
+pipeline:
+  mutators:
+    - image: ghcr.io/kptdev/krm-functions-catalog/set-labels:v0.1.5
+      configMap:
+        k8s-app: headlamp-kpt-demo
+EOF
+
+echo "Kptfile now contains:"
+cat Kptfile
+
+pause
+
+# ─── Step 4 ───────────────────────────────────────────────────────────────────
+banner "Step 4: Run kpt fn render"
+
+run kpt fn render
+
+pause
+
+# ─── Step 5 ───────────────────────────────────────────────────────────────────
+banner "Step 5: Deploy to cluster, expose port, and create service account token"
+
+run kpt live init
+run kpt live apply --reconcile-timeout=5m
+
+echo ""
+echo -e "${GREEN}> kubectl port-forward -n kube-system service/headlamp 8080:80 &${RESET}"
+kubectl port-forward -n kube-system service/headlamp 8080:80 &
+PORT_FORWARD_PID=$!
+echo "Port-forward running (PID: ${PORT_FORWARD_PID})"
+
+echo ""
+echo -e "${GREEN}> kubectl create token headlamp-admin -n kube-system${RESET}"
+TOKEN=$(kubectl create token headlamp-admin -n kube-system)
+
+echo ""
+echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+echo -e "${BOLD}  Headlamp is available at: http://localhost:8080${RESET}"
+echo -e "${BOLD}  Access token:${RESET}"
+echo ""
+echo "${TOKEN}"
+echo -e "${BOLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${RESET}"
+
+pause
+
+# ─── Step 6 ───────────────────────────────────────────────────────────────────
+banner "Step 6: Cleanup"
+
+# The EXIT trap handles cleanup; just print a message and exit cleanly.
+echo -e "${BOLD}Demo complete. Cluster deleted and package removed.${RESET}"


### PR DESCRIPTION
Create a script that runs as a demo, performing the following steps with a prompt request to continue after eaxh step:

step 1:
  * create a kind cluster with the name "kpt-demo"
step 2:
  * create a directory called "headlamp" and cd to it
  * download the KRM file from the headlamp project: https://raw.githubusercontent.com/kubernetes-sigs/headlamp/main/kubernetes-headlamp.yaml
  * Create KRM for the service account and the cluster role binding needed to get the headlamp-admin reconciled
  * run "kpt pkg init" in the directory
step 3:
  * create a pipeline in the Kptfile which mutates the kpt file using the  "set-label" mutator. Change the k8s-app label to "headlamp-kpt-demo"
step 4:
  * run "kpt fn render" to run the pipeline
step 5:
  * run kpt live init, followed by kpt live apply to instantiate the app in  the previously created kind cluster
  * configure the cluster to expose a port so I can access the UI - e.g.  "kubectl port-forward -n kube-system service/headlamp 8080:80"
  * create a service account token:
  kubectl create token headlamp-admin -n kube-system
  * print the token out so I can load it into the browser
step 6:
  * clean up - remove the cluster and the package

this script is intended for use to demonstrate in a simple way how kpt can be applied quickly and easily to automate and manage an existing application with a KRM YAML for deployment.